### PR TITLE
Fix a weird deadlock issue I found

### DIFF
--- a/gen/inc/vkroots_helpers.h
+++ b/gen/inc/vkroots_helpers.h
@@ -140,9 +140,8 @@ namespace vkroots::helpers {
       std::unique_lock lock{ s_mutex };
       
       uint32_t pendingIdx = s_pendingWaitsIdx;
-      Key pending[pendingIdx];
-      
       if ( pendingIdx > 0 ) {
+        Key pending[pendingIdx];
         for (uint32_t i = 0; i < pendingIdx; i++) {
           pending[i]=s_pendingWaits[i];
         }

--- a/gen/inc/vkroots_helpers.h
+++ b/gen/inc/vkroots_helpers.h
@@ -88,17 +88,49 @@ namespace vkroots::helpers {
     using MapData = Data;
 
     static SynchronizedMapObject get(const Key& key) {
-      std::unique_lock lock{ s_mutex };
-      auto iter = s_map.find(key);
-      if (iter == s_map.end())
-        return SynchronizedMapObject{ nullptr };
-      return SynchronizedMapObject{ iter->second, std::move(lock) };
+      {
+	  auto iter = s_map.find(key);
+	  auto waitIter = s_waitMap.find(key);
+
+	  if (waitIter == s_waitMap.end()) {
+	     s_waitMap[key] = false;
+
+	     auto newWaitIter = s_waitMap.find(key);
+	     (newWaitIter->second).wait(false);
+	  }
+	  else if (iter == s_map.end()) {
+	     (waitIter->second).wait(false);
+	  }
+
+      }
+      {
+          std::unique_lock lock{ s_mutex };
+          auto iter = s_map.find(key);
+          if (iter == s_map.end()) {
+            return SynchronizedMapObject{ nullptr };
+          }
+          return SynchronizedMapObject{ iter->second, std::move(lock) };
+      }
     }
 
     static SynchronizedMapObject create(const Key& key, Data data) {
+      {
+      	auto iter = s_waitMap.find(key);
+      	if (iter != s_waitMap.end())
+      	   (iter->second) = false;
+      }
+      
       std::unique_lock lock{ s_mutex };
       auto val = s_map.insert(std::make_pair(key, std::move(data)));
-      return SynchronizedMapObject{ val.first->second, std::move(lock) };
+      auto ret = SynchronizedMapObject{ val.first->second, std::move(lock) };
+
+      {
+      	auto iter = s_waitMap.find(key);
+      	if (iter != s_waitMap.end())
+      	   (iter->second) = true;
+      } 
+
+      return ret;
     }
 
     static bool remove(const Key& key) {
@@ -152,7 +184,10 @@ namespace vkroots::helpers {
 
     Data *m_data;
     std::unique_lock<std::mutex> m_lock;
-
+    
+    static std::unordered_map<Key, std::atomic<bool>> s_waitMap; // latch to avoid deadlocks caused by lock-order-inversion, 
+    //wherein one thread (T1) tries to access data from object A first, and then another (T2) thread is still creating object A
+    //Yet somehow thread T2 ends up getting stuck waiting to acquire the lock for object A
     static std::mutex s_mutex;
     static std::unordered_map<Key, Data> s_map;
   };
@@ -162,7 +197,8 @@ namespace vkroots::helpers {
 
 #define VKROOTS_IMPLEMENT_SYNCHRONIZED_MAP_TYPE(x) \
   template <> std::mutex x::s_mutex = {}; \
-  template <> std::unordered_map<x::MapKey, x::MapData> x::s_map = {};
+  template <> std::unordered_map<x::MapKey, x::MapData> x::s_map = {}; \
+  template <> std::unordered_map<x::MapKey, std::atomic<bool>> x::s_waitMap = {};
 
 }
 

--- a/gen/inc/vkroots_helpers.h
+++ b/gen/inc/vkroots_helpers.h
@@ -89,53 +89,98 @@ namespace vkroots::helpers {
 
     static SynchronizedMapObject get(const Key& key) {
       {
+#ifdef VKROOTS_DEBUG
+      	  printf("in get()\n");
+#endif
 	  auto iter = s_map.find(key);
 	  auto waitIter = s_waitMap.find(key);
+	  if (waitIter == s_waitMap.end() && iter == s_map.end()) {
+	     
+	     uint32_t pendingIdx = (s_pendingWaitsIdx++) + 1; //note: atomic::operator++(int) returns the value *before* the increment
+	     uint32_t targetIndex = pendingIdx + s_waitMapIdx;
+	     
+	     s_pendingWaits[pendingIdx] = key;
 
-	  if (waitIter == s_waitMap.end()) {
-	     s_waitMap[key] = false;
-
-	     auto newWaitIter = s_waitMap.find(key);
-	     (newWaitIter->second).wait(false);
+	     std::atomic<bool> * bAtm = reinterpret_cast<std::atomic<bool> *>(&s_boolPool[targetIndex]);
+	     bAtm->wait(false);
+	     
 	  }
 	  else if (iter == s_map.end()) {
-	     (waitIter->second).wait(false);
+	    std::atomic<bool> * bAtm = reinterpret_cast<std::atomic<bool> *>(waitIter->second);
+	    bAtm->wait(false);
 	  }
 
       }
       {
           std::unique_lock lock{ s_mutex };
           auto iter = s_map.find(key);
+#ifdef VKROOTS_DEBUG
+          printf("out of get()\n");
+#endif
           if (iter == s_map.end()) {
             return SynchronizedMapObject{ nullptr };
           }
           return SynchronizedMapObject{ iter->second, std::move(lock) };
       }
+      
     }
 
     static SynchronizedMapObject create(const Key& key, Data data) {
+#ifdef VKROOTS_DEBUG
+      printf("in create()\n");
+#endif
       {
       	auto iter = s_waitMap.find(key);
-      	if (iter != s_waitMap.end())
-      	   (iter->second) = false;
-      }
-      
-      std::unique_lock lock{ s_mutex };
-      auto val = s_map.insert(std::make_pair(key, std::move(data)));
-      auto ret = SynchronizedMapObject{ val.first->second, std::move(lock) };
-
-      {
-      	auto iter = s_waitMap.find(key);
-      	if (iter != s_waitMap.end())
-      	   (iter->second) = true;
+      	if (iter != s_waitMap.end()) {
+      	   std::atomic<bool> * bAtm = reinterpret_cast<std::atomic<bool> *>(iter->second);
+      	   bAtm->store(false);
+      	}
       } 
 
+      std::unique_lock lock{ s_mutex };
+      
+      uint32_t pendingIdx = s_pendingWaitsIdx;
+      Key pending[pendingIdx];
+      
+      if ( pendingIdx > 0 ) {
+        for (uint32_t i = 0; i < pendingIdx; i++) {
+          pending[i]=s_pendingWaits[i];
+        }
+        
+        uint32_t mapIdx = s_waitMapIdx;
+        
+        for (uint32_t i = mapIdx; i < mapIdx + pendingIdx; i++) {
+            s_waitMap[pending[i-mapIdx]] = &s_boolPool[i];
+        }
+        
+        s_pendingWaitsIdx -= pendingIdx;
+        s_waitMapIdx += pendingIdx;
+      }
+      
+      auto val = s_map.insert(std::make_pair(key, std::move(data)));
+      auto ret = SynchronizedMapObject{ val.first->second, std::move(lock) };
+      {
+      	auto iter = s_waitMap.find(key);
+      	if (iter != s_waitMap.end()) {
+      	   std::atomic<bool> * bAtm = reinterpret_cast<std::atomic<bool> *>(iter->second);
+      	   bAtm->store(true);
+      	}
+      }
+#ifdef VKROOTS_DEBUG 
+      printf("out of create()\n");
+#endif
       return ret;
     }
 
     static bool remove(const Key& key) {
+#ifdef VKROOTS_DEBUG
+      printf("in remove()\n");
+#endif
       std::unique_lock lock{ s_mutex };
       auto iter = s_map.find(key);
+#ifdef VKROOTS_DEBUG
+      printf("out of remove()\n");
+#endif
       if (iter == s_map.end())
         return false;
       s_map.erase(iter);
@@ -184,10 +229,17 @@ namespace vkroots::helpers {
 
     Data *m_data;
     std::unique_lock<std::mutex> m_lock;
-    
-    static std::unordered_map<Key, std::atomic<bool>> s_waitMap; // latch to avoid deadlocks caused by lock-order-inversion, 
+
+    static std::array<bool, 64> s_boolPool;
+
+    static std::unordered_map<Key, bool*> s_waitMap; // latch to avoid deadlocks caused by lock-order-inversion, 
     //wherein one thread (T1) tries to access data from object A first, and then another (T2) thread is still creating object A
     //Yet somehow thread T2 ends up getting stuck waiting to acquire the lock for object A
+    static std::atomic<uint32_t> s_waitMapIdx; 
+    
+    static Key s_pendingWaits[64];
+    static std::atomic<uint32_t> s_pendingWaitsIdx;
+    
     static std::mutex s_mutex;
     static std::unordered_map<Key, Data> s_map;
   };
@@ -198,7 +250,11 @@ namespace vkroots::helpers {
 #define VKROOTS_IMPLEMENT_SYNCHRONIZED_MAP_TYPE(x) \
   template <> std::mutex x::s_mutex = {}; \
   template <> std::unordered_map<x::MapKey, x::MapData> x::s_map = {}; \
-  template <> std::unordered_map<x::MapKey, std::atomic<bool>> x::s_waitMap = {};
+  template <> std::unordered_map<x::MapKey, bool*> x::s_waitMap = {}; \
+  template <> x::MapKey x::s_pendingWaits[64] = {}; \
+  template <> std::atomic<uint32_t> x::s_waitMapIdx = 0; \
+  template <> std::atomic<uint32_t> x::s_pendingWaitsIdx = 0; \
+  template <> std::array<bool, 64> x::s_boolPool = {};
 
 }
 

--- a/gen/inc/vkroots_includes.h
+++ b/gen/inc/vkroots_includes.h
@@ -20,6 +20,7 @@
 #include <string_view>
 #include <array>
 #include <functional>
+#include <atomic>
 
 #define VKROOTS_VERSION_MAJOR 0
 #define VKROOTS_VERSION_MINOR 1

--- a/vkroots.h
+++ b/vkroots.h
@@ -16799,7 +16799,8 @@ namespace vkroots::helpers {
 
 #define VKROOTS_IMPLEMENT_SYNCHRONIZED_MAP_TYPE(x) \
   template <> std::mutex x::s_mutex = {}; \
-  template <> std::unordered_map<x::MapKey, x::MapData> x::s_map = {};
+  template <> std::unordered_map<x::MapKey, x::MapData> x::s_map = {}; \
+  template <> std::unordered_map<x::MapKey, std::atomic<bool>> x::s_waitMap = {};
 
 }
 

--- a/vkroots.h
+++ b/vkroots.h
@@ -19,8 +19,8 @@
 #include <optional>
 #include <string_view>
 #include <array>
-#include <atomic>
 #include <functional>
+#include <atomic>
 
 #define VKROOTS_VERSION_MAJOR 0
 #define VKROOTS_VERSION_MINOR 1
@@ -16741,9 +16741,8 @@ namespace vkroots::helpers {
       std::unique_lock lock{ s_mutex };
       
       uint32_t pendingIdx = s_pendingWaitsIdx;
-      Key pending[pendingIdx];
-      
       if ( pendingIdx > 0 ) {
+        Key pending[pendingIdx];
         for (uint32_t i = 0; i < pendingIdx; i++) {
           pending[i]=s_pendingWaits[i];
         }


### PR DESCRIPTION
There seems to be certain situations where the SynchronizedMapObject::get() runs before SynchronizedMapObject::create(). 

I've specifically observed this when running qemu-gtk ui ontop of gamescope, but only when running the gtk ui with gl on and being translated to vulkan w/ the zink driver and also either turning fullscreen on or turning the gtk-ui's menubar off...
(the weird specificity seems to be due to this issue only being triggered when the gamescope layer was bypassing xwayland, not sure why I only saw the issue when it was bypassing xwayland tho...)
After compiling qemu w/ thread sanitizer on, tsan found a `lock-order-inversion (potential deadlock)` issue around `vkroots::helpers::SynchronizedMapObject<>`:
<details>
<summary>WARNING: ThreadSanitizer: lock-order-inversion (potential deadlock) (pid=35532)</summary>

``` 
Cycle in lock order graph: M0 (0x7f3ec4b1f240) => M1 (0x7f3ec4b1f1c0) => M0

  Mutex M1 acquired here while holding mutex M0 in main thread:
    #0 pthread_mutex_lock /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4481 (libtsan.so.2+0x560df) (BuildId: c39405aada755398a542cde01e23149afb1204d1)
    #1 __gthread_mutex_lock /usr/include/c++/13.2.1/x86_64-pc-linux-gnu/bits/gthr-default.h:749 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xe5e1) (BuildId: 66a463a75ac17b21b60c43e6e8b5daf9453c2a4d)
    #2 std::mutex::lock() /usr/include/c++/13.2.1/bits/std_mutex.h:113 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xe5e1)
    #3 std::unique_lock<std::mutex>::lock() /usr/include/c++/13.2.1/bits/unique_lock.h:141 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xe5e1)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/include/c++/13.2.1/bits/unique_lock.h:71 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xe5e1)
    #5 vkroots::helpers::SynchronizedMapObject<VkSwapchainKHR_T*, GamescopeWSILayer::GamescopeSwapchainData>::create(VkSwapchainKHR_T* const&, GamescopeWSILayer::GamescopeSwapchainData) ../subprojects/vkroots/vkroots.h:14157 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xe5e1)
    #6 GamescopeWSILayer::VkDeviceOverrides::CreateSwapchainKHR(vkroots::VkDeviceDispatch const*, VkDevice_T*, VkSwapchainCreateInfoKHR const*, VkAllocationCallbacks const*, VkSwapchainKHR_T**) ../layer/VkLayer_FROG_gamescope_wsi.cpp:880 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xe5e1)
    #7 gd_egl_init ../qemu-8.2.1/ui/gtk-egl.c:60 (ui-gtk.so+0x81e0) (BuildId: 733666354da3902daf2398eb744ceeccf9c5c0f7)
    #8 gd_egl_refresh ../qemu-8.2.1/ui/gtk-egl.c:157 (ui-gtk.so+0x8607) (BuildId: 733666354da3902daf2398eb744ceeccf9c5c0f7)
    #9 gui_update <null> (qemu-system-x86_64+0xf1d804) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #10 timerlist_run_timers.part.0 <null> (qemu-system-x86_64+0x95a0e2) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #11 qemu_clock_run_all_timers <null> (qemu-system-x86_64+0x95a387) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #12 main_loop_wait <null> (qemu-system-x86_64+0x960acb) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #13 qemu_default_main <null> (qemu-system-x86_64+0xb6f806) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #14 main <null> (qemu-system-x86_64+0x463632) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)

  Mutex M0 previously acquired by the same thread here:
    #0 pthread_mutex_lock /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4481 (libtsan.so.2+0x560df) (BuildId: c39405aada755398a542cde01e23149afb1204d1)
    #1 __gthread_mutex_lock /usr/include/c++/13.2.1/x86_64-pc-linux-gnu/bits/gthr-default.h:749 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xddce) (BuildId: 66a463a75ac17b21b60c43e6e8b5daf9453c2a4d)
    #2 std::mutex::lock() /usr/include/c++/13.2.1/bits/std_mutex.h:113 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xddce)
    #3 std::unique_lock<std::mutex>::lock() /usr/include/c++/13.2.1/bits/unique_lock.h:141 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xddce)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/include/c++/13.2.1/bits/unique_lock.h:71 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xddce)
    #5 vkroots::helpers::SynchronizedMapObject<VkSurfaceKHR_T*, GamescopeWSILayer::GamescopeSurfaceData>::get(VkSurfaceKHR_T* const&) ../subprojects/vkroots/vkroots.h:14148 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xddce)
    #6 GamescopeWSILayer::VkDeviceOverrides::CreateSwapchainKHR(vkroots::VkDeviceDispatch const*, VkDevice_T*, VkSwapchainCreateInfoKHR const*, VkAllocationCallbacks const*, VkSwapchainKHR_T**) ../layer/VkLayer_FROG_gamescope_wsi.cpp:779 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0xddce)
    #7 gd_egl_init ../qemu-8.2.1/ui/gtk-egl.c:60 (ui-gtk.so+0x81e0) (BuildId: 733666354da3902daf2398eb744ceeccf9c5c0f7)
    #8 gd_egl_refresh ../qemu-8.2.1/ui/gtk-egl.c:157 (ui-gtk.so+0x8607) (BuildId: 733666354da3902daf2398eb744ceeccf9c5c0f7)
    #9 gui_update <null> (qemu-system-x86_64+0xf1d804) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #10 timerlist_run_timers.part.0 <null> (qemu-system-x86_64+0x95a0e2) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #11 qemu_clock_run_all_timers <null> (qemu-system-x86_64+0x95a387) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #12 main_loop_wait <null> (qemu-system-x86_64+0x960acb) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #13 qemu_default_main <null> (qemu-system-x86_64+0xb6f806) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #14 main <null> (qemu-system-x86_64+0x463632) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)

  Mutex M0 acquired here while holding mutex M1 in thread T13:
    #0 pthread_mutex_lock /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4481 (libtsan.so.2+0x560df) (BuildId: c39405aada755398a542cde01e23149afb1204d1)
    #1 __gthread_mutex_lock /usr/include/c++/13.2.1/x86_64-pc-linux-gnu/bits/gthr-default.h:749 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x128f3) (BuildId: 66a463a75ac17b21b60c43e6e8b5daf9453c2a4d)
    #2 std::mutex::lock() /usr/include/c++/13.2.1/bits/std_mutex.h:113 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x128f3)
    #3 std::unique_lock<std::mutex>::lock() /usr/include/c++/13.2.1/bits/unique_lock.h:141 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x128f3)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/include/c++/13.2.1/bits/unique_lock.h:71 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x128f3)
    #5 vkroots::helpers::SynchronizedMapObject<VkSurfaceKHR_T*, GamescopeWSILayer::GamescopeSurfaceData>::get(VkSurfaceKHR_T* const&) ../subprojects/vkroots/vkroots.h:14148 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x128f3)
    #6 GamescopeWSILayer::VkDeviceOverrides::QueuePresentKHR(vkroots::VkDeviceDispatch const*, VkQueue_T*, VkPresentInfoKHR const*) ../layer/VkLayer_FROG_gamescope_wsi.cpp:972 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x128f3)
    #7 wrap_QueuePresentKHR<GamescopeWSILayer::VkInstanceOverrides, vkroots::NoOverrides, GamescopeWSILayer::VkDeviceOverrides> ../subprojects/vkroots/vkroots.h:5544 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x128f3)

  Mutex M1 previously acquired by the same thread here:
    #0 pthread_mutex_lock /usr/src/debug/gcc/gcc/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:4481 (libtsan.so.2+0x560df) (BuildId: c39405aada755398a542cde01e23149afb1204d1)
    #1 __gthread_mutex_lock /usr/include/c++/13.2.1/x86_64-pc-linux-gnu/bits/gthr-default.h:749 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x12840) (BuildId: 66a463a75ac17b21b60c43e6e8b5daf9453c2a4d)
    #2 std::mutex::lock() /usr/include/c++/13.2.1/bits/std_mutex.h:113 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x12840)
    #3 std::unique_lock<std::mutex>::lock() /usr/include/c++/13.2.1/bits/unique_lock.h:141 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x12840)
    #4 std::unique_lock<std::mutex>::unique_lock(std::mutex&) /usr/include/c++/13.2.1/bits/unique_lock.h:71 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x12840)
    #5 vkroots::helpers::SynchronizedMapObject<VkSwapchainKHR_T*, GamescopeWSILayer::GamescopeSwapchainData>::get(VkSwapchainKHR_T* const&) ../subprojects/vkroots/vkroots.h:14148 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x12840)
    #6 GamescopeWSILayer::VkDeviceOverrides::QueuePresentKHR(vkroots::VkDeviceDispatch const*, VkQueue_T*, VkPresentInfoKHR const*) ../layer/VkLayer_FROG_gamescope_wsi.cpp:964 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x12840)
    #7 wrap_QueuePresentKHR<GamescopeWSILayer::VkInstanceOverrides, vkroots::NoOverrides, GamescopeWSILayer::VkDeviceOverrides> ../subprojects/vkroots/vkroots.h:5544 (libVkLayer_FROG_gamescope_wsi_x86_64.so+0x12840)

  Thread T13 'qemu-syst:zfq0' (tid=35661, running) created by main thread at:
    #0 pthread_create /usr/src/debug/gcc/gcc/libsanitizer/tsan/tsan_interceptors_posix.cpp:1036 (libtsan.so.2+0x44219) (BuildId: c39405aada755398a542cde01e23149afb1204d1)
    #1 <null> <null> (zink_dri.so+0x112d0b) (BuildId: f57bdf5022f3629188b9a5edc0dd30b3b3e65a31)
    #2 qemu_egl_init_dpy_x11 ../qemu-8.2.1/ui/egl-helpers.c:535 (ui-opengl.so+0x5346) (BuildId: 9a4f0557397dfaebd60c5ce30f7b6d43571e4517)
    #3 gtk_egl_init ../qemu-8.2.1/ui/gtk-egl.c:382 (ui-gtk.so+0x1112c) (BuildId: 733666354da3902daf2398eb744ceeccf9c5c0f7)
    #4 early_gtk_display_init ../qemu-8.2.1/ui/gtk.c:2520 (ui-gtk.so+0x1112c)
    #5 early_gtk_display_init ../qemu-8.2.1/ui/gtk.c:2476 (ui-gtk.so+0x1112c)
    #6 qemu_display_early_init <null> (qemu-system-x86_64+0xf1b9df) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #7 qemu_init <null> (qemu-system-x86_64+0x89bca2) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)
    #8 main <null> (qemu-system-x86_64+0x46361f) (BuildId: 0d35d414881c3c226719e772213be1005618cb03)

SUMMARY: ThreadSanitizer: lock-order-inversion (potential deadlock) /usr/include/c++/13.2.1/x86_64-pc-linux-gnu/bits/gthr-default.h:749 in __gthread_mutex_lock
``` 
</details>

After recompiling gamescope w/ this PR applied to vkroots, the issue I was seeing went away

~~**UPDATE**: need to iron this out a bit~~

**UPDATE 2**: I've made the deadlock avoidance more robust, though I will say that one weird thing I noticed is that while this PR allows gamescope WSI to work when running something like `GAMESCOPE_WSI_FORCE_BYPASS=1 gamescope -- env MESA_LOADER_DRIVER_OVERRIDE=zink qemu-system-x86_64 -display gtk,gl=on,show-menubar=off`
omitting the `GAMESCOPE_WSI_FORCE_BYPASS=1` causes it to crash again...
oh well, I guess this is good enough for now...