### PR TITLE
Fix pkgconfig install dir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -18,5 +18,6 @@ pkgconfig.generate(
   filebase: meson.project_name(),
   name: meson.project_name(),
   description: 'Vulkan layers library',
-  subdirs: '.'
+  subdirs: '.',
+  install_dir: 'share/pkgconfig'
 )


### PR DESCRIPTION
By default pkgconfig files installed in `${libdir}/pkgconfig`.
But for multilib packages they should be either in both `lib64` and `lib` (`lib` and `lib32` in some distros)
or in `/usr/share/pkgconfig`.

Installing `vkroots.pc` in `${prefix}/share/pkgconfig` make vkroots visible for e.g. both 32 and 64 bit builds.