### PR TITLE
Use vkGetDeviceQueue2 for queues created with non-zero flags

### DIFF
--- a/gen/inc/vkroots_dispatches.h
+++ b/gen/inc/vkroots_dispatches.h
@@ -21,6 +21,28 @@ namespace vkroots::tables {
     }
   }
 
+  // Queues created with non-zero VkDeviceQueueCreateFlags (eg. PROTECTED_BIT or
+  // INTERNALLY_SYNCHRONIZED_BIT_KHR) cannot be retrieved with vkGetDeviceQueue,
+  // which returns VK_NULL_HANDLE for them. Use vkGetDeviceQueue2 with matching
+  // flags for those, and keep the original call for flag-less queues so
+  // Vulkan 1.0 devices remain unaffected.
+  static inline VkQueue GetDeviceQueueByCreateInfo(const VkDeviceDispatch *deviceDispatch, VkDevice device, const VkDeviceQueueCreateInfo& queueInfo, uint32_t queueIndex) {
+    VkQueue queue = VK_NULL_HANDLE;
+    if (queueInfo.flags) {
+      VkDeviceQueueInfo2 queueInfo2 = {
+        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2,
+        .pNext = nullptr,
+        .flags = queueInfo.flags,
+        .queueFamilyIndex = queueInfo.queueFamilyIndex,
+        .queueIndex = queueIndex,
+      };
+      deviceDispatch->GetDeviceQueue2(device, &queueInfo2, &queue);
+    } else {
+      deviceDispatch->GetDeviceQueue(device, queueInfo.queueFamilyIndex, queueIndex, &queue);
+    }
+    return queue;
+  }
+
   static inline void CreateDispatchTable(const VkDeviceCreateInfo* pCreateInfo, PFN_vkGetDeviceProcAddr nextProcAddr, VkPhysicalDevice physicalDevice, VkDevice device) {
     auto physicalDeviceDispatch = vkroots::LookupDispatch(physicalDevice);
     auto deviceDispatch = DeviceDispatches.create(device, nextProcAddr, device, physicalDevice, physicalDeviceDispatch, pCreateInfo);
@@ -28,8 +50,7 @@ namespace vkroots::tables {
     for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; i++) {
       const auto &queueInfo = pCreateInfo->pQueueCreateInfos[i];
       for (uint32_t j = 0; j < queueInfo.queueCount; j++) {
-        VkQueue queue;
-        deviceDispatch->GetDeviceQueue(device, queueInfo.queueFamilyIndex, j, &queue);
+        VkQueue queue = GetDeviceQueueByCreateInfo(deviceDispatch, device, queueInfo, j);
 
         tables::AssignDispatchTable(queue, deviceDispatch);
       }
@@ -66,8 +87,7 @@ namespace vkroots::tables {
 
     for (const auto& queueInfo : deviceDispatch->DeviceQueueInfos) {
       for (uint32_t i = 0; i < queueInfo.queueCount; i++) {
-        VkQueue queue;
-        deviceDispatch->GetDeviceQueue(device, queueInfo.queueFamilyIndex, i, &queue);
+        VkQueue queue = GetDeviceQueueByCreateInfo(deviceDispatch, device, queueInfo, i);
         tables::UnassignDispatchTable(queue);
       }
     }

--- a/vkroots.h
+++ b/vkroots.h
@@ -24982,6 +24982,28 @@ namespace vkroots::tables {
     }
   }
 
+  // Queues created with non-zero VkDeviceQueueCreateFlags (eg. PROTECTED_BIT or
+  // INTERNALLY_SYNCHRONIZED_BIT_KHR) cannot be retrieved with vkGetDeviceQueue,
+  // which returns VK_NULL_HANDLE for them. Use vkGetDeviceQueue2 with matching
+  // flags for those, and keep the original call for flag-less queues so
+  // Vulkan 1.0 devices remain unaffected.
+  static inline VkQueue GetDeviceQueueByCreateInfo(const VkDeviceDispatch *deviceDispatch, VkDevice device, const VkDeviceQueueCreateInfo& queueInfo, uint32_t queueIndex) {
+    VkQueue queue = VK_NULL_HANDLE;
+    if (queueInfo.flags) {
+      VkDeviceQueueInfo2 queueInfo2 = {
+        .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2,
+        .pNext = nullptr,
+        .flags = queueInfo.flags,
+        .queueFamilyIndex = queueInfo.queueFamilyIndex,
+        .queueIndex = queueIndex,
+      };
+      deviceDispatch->GetDeviceQueue2(device, &queueInfo2, &queue);
+    } else {
+      deviceDispatch->GetDeviceQueue(device, queueInfo.queueFamilyIndex, queueIndex, &queue);
+    }
+    return queue;
+  }
+
   static inline void CreateDispatchTable(const VkDeviceCreateInfo* pCreateInfo, PFN_vkGetDeviceProcAddr nextProcAddr, VkPhysicalDevice physicalDevice, VkDevice device) {
     auto physicalDeviceDispatch = vkroots::LookupDispatch(physicalDevice);
     auto deviceDispatch = DeviceDispatches.create(device, nextProcAddr, device, physicalDevice, physicalDeviceDispatch, pCreateInfo);
@@ -24989,8 +25011,7 @@ namespace vkroots::tables {
     for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; i++) {
       const auto &queueInfo = pCreateInfo->pQueueCreateInfos[i];
       for (uint32_t j = 0; j < queueInfo.queueCount; j++) {
-        VkQueue queue;
-        deviceDispatch->GetDeviceQueue(device, queueInfo.queueFamilyIndex, j, &queue);
+        VkQueue queue = GetDeviceQueueByCreateInfo(deviceDispatch, device, queueInfo, j);
 
         tables::AssignDispatchTable(queue, deviceDispatch);
       }
@@ -25027,8 +25048,7 @@ namespace vkroots::tables {
 
     for (const auto& queueInfo : deviceDispatch->DeviceQueueInfos) {
       for (uint32_t i = 0; i < queueInfo.queueCount; i++) {
-        VkQueue queue;
-        deviceDispatch->GetDeviceQueue(device, queueInfo.queueFamilyIndex, i, &queue);
+        VkQueue queue = GetDeviceQueueByCreateInfo(deviceDispatch, device, queueInfo, i);
         tables::UnassignDispatchTable(queue);
       }
     }


### PR DESCRIPTION
`tables::CreateDispatchTable(const VkDeviceCreateInfo*, ...)` and `tables::DestroyDispatchTable(VkDevice)` retrieve every queue with legacy `vkGetDeviceQueue`. Per the Vulkan spec, that function is only valid for queues created with `flags == 0` and returns `VK_NULL_HANDLE` otherwise — so any queue created with `VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT` or the new `VK_DEVICE_QUEUE_CREATE_INTERNALLY_SYNCHRONIZED_BIT_KHR` funnels `VK_NULL_HANDLE` into `AssignDispatchTable`, which hits `assert(obj)` in the dispatch-table map and aborts the process.

This recently became a real-world crash: Mesa 26.1 advertises `VK_KHR_internally_synchronized_queues`, and libplacebo since videolan/libplacebo!809 creates all queues with the INTERNALLY_SYNCHRONIZED flag when available. Every libplacebo-based app (Moonlight, mpv master, ...) now aborts inside gamescope's WSI layer on launch in a gamescope session. Reported downstream at moonlight-stream/moonlight-qt#1925 / moonlight-stream/moonlight-qt#1930; crash trace from a Steam Deck on SteamOS 3.8.14:

```
Signal: 6 (ABRT)
#4  libVkLayer_FROG_gamescope_wsi_x86_64.so + 0x67c5   (vkroots.h:129 assert(obj))
#5  libvulkan.so.1.4.321
#8  libplacebo.so.365 (pl_vulkan_create)
```

Fix: add a `GetDeviceQueueByCreateInfo` helper that uses `vkGetDeviceQueue2` with the create-time flags when `queueInfo.flags != 0`, falling back to the original `vkGetDeviceQueue` for flag-less queues so Vulkan 1.0 devices are unaffected. The create-time flags were already captured in `VkDeviceDispatch::DeviceQueueInfos` and `GetDeviceQueue2` was already in the dispatch table — this just wires them together. Both the create and destroy paths are updated, and `vkroots.h` is regenerated with `gen/make_vkroots` (no other diff).

Verified against the crash above: with this change applied, libplacebo device creation succeeds under the gamescope WSI layer (tested on Steam Deck Game Mode via the equivalent libplacebo-side change; the layer-side fix was compile-checked with clang -std=c++20).

A gamescope-side `subprojects/vkroots` bump will be needed for this to reach the WSI layer (vendored copy there dates to April 2024) — filing an issue there referencing this PR.
